### PR TITLE
node 18 build

### DIFF
--- a/buildpack-18/Dockerfile
+++ b/buildpack-18/Dockerfile
@@ -14,7 +14,7 @@ RUN set -xe && \
         wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
         apt-get update && \
         apt-get install -y --no-install-recommends postgresql-client-11 && \
-        if [ $(dpkg --print-architecture) = "arm64" ];then apt-get install -y --no-install-recommends phantomjs; fi && \
+        # if [ $(dpkg --print-architecture) = "arm64" ];then apt-get install -y --no-install-recommends phantomjs; fi && \
         rm -rf /var/lib/apt/lists/* && \
         # upgrade npm to 6.10
         npm i -g npm@9.6.0 && \

--- a/buildpack-18/Dockerfile
+++ b/buildpack-18/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.16.0-bullseye
+FROM node:18.20.4-bullseye
 
 ENV DEBIAN_VERSION_NAME bullseye
 

--- a/runtime-18/Dockerfile
+++ b/runtime-18/Dockerfile
@@ -20,7 +20,7 @@ RUN set -xe && \
         wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
         apt-get update && \
         apt-get install -y --no-install-recommends postgresql-client-11 && \
-        if [ $(dpkg --print-architecture) = "arm64" ];then apt-get install -y --no-install-recommends phantomjs; fi && \
+        # if [ $(dpkg --print-architecture) = "arm64" ];then apt-get install -y --no-install-recommends phantomjs; fi && \
         rm -rf /var/lib/apt/lists/* && \
         # install pchecker
         wget https://github.com/hackmdio/portchecker/releases/download/${PORTCHECKER_VERSION}/portchecker-linux-$(dpkg --print-architecture).tar.gz && \
@@ -45,4 +45,3 @@ ENV PATH="/home/hackmd/.npm/bin:$PATH"
 WORKDIR /home/$USER_NAME/app
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["node"]
-

--- a/runtime-18/Dockerfile
+++ b/runtime-18/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.16.0-bullseye
+FROM node:18.20.4-bullseye
 
 ENV DEBIAN_VERSION_NAME=bullseye NODE_ENV=production
 ENV PORTCHECKER_VERSION=v1.1.0


### PR DESCRIPTION
- **chore: bump base image to 18.20.4-bullseye**
- **fix: remove phantomjs installation**
