### PR TITLE
chore: bump node 24 buildpack/runtime to 24.14.0

### DIFF
--- a/buildpack-24/Dockerfile
+++ b/buildpack-24/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24.11.0-bookworm
+FROM node:24.14.0-bookworm
 
 ENV DEBIAN_VERSION_NAME=bookworm
 

--- a/runtime-24/Dockerfile
+++ b/runtime-24/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24.11.0-bookworm
+FROM node:24.14.0-bookworm
 
 ENV DEBIAN_VERSION_NAME=bookworm
 ENV NODE_ENV=production


### PR DESCRIPTION
Update Node 24 base images to 24.14.0 so both buildpack and runtime track the latest 24.14.x patch release.

